### PR TITLE
DO NOT MERGE, local for Proof of concept -- Adds per-repo config 'git_env' which whitelists GIT_* env vars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install: pip install coveralls tox
 script: tox
 before_install:
     # work around https://github.com/travis-ci/travis-ci/issues/8363
-    - pyenv global system 3.5
+    - which python3.5 || (pyenv install 3.5.4 && pyenv global system 3.5.4)
     - git --version
     - |
         if [ "$LATEST_GIT" = "1" ]; then

--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -77,10 +77,9 @@ def no_git_env():
     # GIT_DIR: Causes git clone to clone wrong thing
     # GIT_INDEX_FILE: Causes 'error invalid object ...' during commit
 
-    # list of explicitly whitelisted variables
-    allowed_git_envs = ['GIT_SSH']
     return {
-        k: v for k, v in os.environ.items() if not k.startswith('GIT_') or k in allowed_git_envs
+        k: v for k, v in os.environ.items()
+        if not k.startswith('GIT_') or k in {'GIT_SSH'}
     }
 
 

--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -76,8 +76,11 @@ def no_git_env():
     # while running pre-commit hooks in submodules.
     # GIT_DIR: Causes git clone to clone wrong thing
     # GIT_INDEX_FILE: Causes 'error invalid object ...' during commit
+
+    # list of explicitly whitelisted variables
+    allowed_git_envs = ['GIT_SSH']
     return {
-        k: v for k, v in os.environ.items() if not k.startswith('GIT_')
+        k: v for k, v in os.environ.items() if not k.startswith('GIT_') or k in allowed_git_envs
     }
 
 

--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -76,7 +76,6 @@ def no_git_env():
     # while running pre-commit hooks in submodules.
     # GIT_DIR: Causes git clone to clone wrong thing
     # GIT_INDEX_FILE: Causes 'error invalid object ...' during commit
-
     return {
         k: v for k, v in os.environ.items()
         if not k.startswith('GIT_') or k in {'GIT_SSH'}


### PR DESCRIPTION
I do not necessarily like this idea -- this approach seems heavy handed compared to the simple problem it's trying to solve.

The change allows an entry in the pre-commit yaml config file, under a repo heading, which is a list of SSH environment variables to whitelist:
```
-   repo: git://server/my_private/pre-commit-hooks
    sha: 616d91d4032cef3d742f85168387a4bfd66e2a05
    git_env:
        - GIT_SSH
        - ...
    hooks:
        - ...
```

This change was needed because pre-commit clears GIT_* env vars when the repos are fetched via git binary in the subprocess call.

This is one way to solve for a very specific use case: A project builds but needs authenticated git access to a private repo -- and the GIT_SSH env var is set to help facilitate. There are quite a lot of GIT_* env vars and while some certainly cause issues, if they were explicitly whitelisted, at least it would be possible to see, at a glance, where the issue could be.

Other, probably simpler ways - 
  * simply allow GIT_SSH, hard-coded, as an exception.
  * take the list of allowed vars from the environment.
  * make no changes and folks would probably get clever.


